### PR TITLE
Fix app compilation for arm macOS

### DIFF
--- a/src/macos/BuildMacos.zig
+++ b/src/macos/BuildMacos.zig
@@ -29,6 +29,11 @@ pub fn create(owner: *std.Build, options: Options) *BuildMacos {
     });
     object.bundle_compiler_rt = true;
 
+    const compile_target = owner.fmt("{s}-apple-macosx{}", .{
+        if (options.target.result.cpu.arch == .aarch64) "arm64" else @tagName(options.target.result.cpu.arch),
+        options.target.result.os.version_range.semver.min,
+    });
+
     const swiftc = owner.addSystemCommand(&.{
         "swiftc",
         if (options.optimize == .Debug) "-Onone" else "-O",
@@ -37,7 +42,7 @@ pub fn create(owner: *std.Build, options: Options) *BuildMacos {
         "-lc++",
         "-lsqlite3",
         "-target",
-        owner.fmt("{s}-apple-macosx{}", .{ @tagName(options.target.result.cpu.arch), options.target.result.os.version_range.semver.min }),
+        compile_target,
         "-o",
     });
 


### PR DESCRIPTION
The current build process fails when running on an arm64 machine targeting arm64, due to differing architecture naming conventions between Zig (`aarch64`) and swiftc (`arm64`). This PR resolves the issue by checking if the target is macOS `aarch64` and replacing it with `arm64`.

JVF